### PR TITLE
Have serialterm get USB port from  environment variable

### DIFF
--- a/tools/scripts/serialterm.sh
+++ b/tools/scripts/serialterm.sh
@@ -1,1 +1,1 @@
-osascript -e 'tell application "Terminal" to do script "screen /dev/cu.usbmodem1411 9600"' 
+osascript -e 'tell application "Terminal" to do script "screen $BOARD_COM 9600"' 


### PR DESCRIPTION
Fix to serialterm so that it uses USB port as defined in the BOARD_COM environment variable.